### PR TITLE
Clarification added

### DIFF
--- a/en/waves-node/extensions/matcher/matcher-install-ubuntu-deb.md
+++ b/en/waves-node/extensions/matcher/matcher-install-ubuntu-deb.md
@@ -207,4 +207,6 @@ Considering other node parameters is out of current article scope. To get more i
     </li>
 </ol>
 
-As a result, the matcher account address will be displayed. Congratulations, you've successfully installed the matcher.
+As a result, the *public key* will be shown. This key should not be confused with your wallet's address. You can view your *public key* by issuing `waves-dex-cli create-account-seed --address-scheme W --seed-format raw-string --account-nonce 0`.
+
+Congratulations, you've successfully installed the matcher!


### PR DESCRIPTION
The address that is displayed is not the usual Waves wallet address but its (base58 encoded) "public key".